### PR TITLE
docs: Fix a few typos

### DIFF
--- a/en/pygame/014_sprites.py
+++ b/en/pygame/014_sprites.py
@@ -147,7 +147,7 @@ while mainloop:
     
     pygame.display.set_caption("[FPS]: %.2f birds: %i" % (clock.get_fps(), len(birdgroup)))
     
-    # ------ collision detecttion
+    # ------ collision detection
     for bird in birdgroup:
         bird.catched = False   # set all Bird sprites to not catched
         

--- a/en/pygame/015_more_sprites.py
+++ b/en/pygame/015_more_sprites.py
@@ -341,7 +341,7 @@ def game():
         pygame.display.set_caption("ms: %i max(ms): %i fps: %.2f birds: %i gravity: %s bad:%s clever:%s"% (milliseconds, 
                                     millimax, clock.get_fps(), len(birdgroup), Fragment.gravity, badcoding, clevercoding))
         
-        # ------ collision detecttion
+        # ------ collision detection
         for bird in birdgroup:
             bird.cleanstatus()
             

--- a/en/pygame/part2step014-sprites.py
+++ b/en/pygame/part2step014-sprites.py
@@ -137,7 +137,7 @@ while mainloop:
     
     pygame.display.set_caption("[FPS]: %.2f birds: %i" % (clock.get_fps(), len(birdgroup)))
     
-    # ------ collision detecttion
+    # ------ collision detection
     for bird in birdgroup:
         bird.catched = False   # set all Bird sprites to not catched
         

--- a/en/python/battleship/chat_server.py
+++ b/en/python/battleship/chat_server.py
@@ -7,7 +7,7 @@ from threading import Thread
 def accept_incoming_connections():
     """Sets up handling for incoming clients."""
     while True:
-        client, client_address = SERVER.accept()   # client_adress is ip and port
+        client, client_address = SERVER.accept()   # client_address is ip and port
         print("client {}:{} has connected with server".format(client_address[0], client_address[1]))
         #client.send(bytes("Welcome to Battleships! Please type your name and press enter!", "utf8"))
         addresses[client] = client_address

--- a/en/python/tictactoe/step003c_play_until_bored.py
+++ b/en/python/tictactoe/step003c_play_until_bored.py
@@ -1,6 +1,6 @@
 """tic tac toe for 2 players, without win checking"""
 
-# ----- defnine some top-level variables ------
+# ----- define some top-level variables ------
 cells = [[" ", " ", " "],
          [" ", " ", " "],
          [" ", " ", " "],

--- a/en/python/tictactoe/step004a_check_win.py
+++ b/en/python/tictactoe/step004a_check_win.py
@@ -1,5 +1,5 @@
 """tic tac toe for 2 players, wit win checking"""
-# ----- defnine some top-level variables ------
+# ----- define some top-level variables ------
 cells = [[" " for x in range(3)] for y in range(3)]
 symbols = ("x", "o")      # tuples are read-only
 greeting = "This is turn {}. Player {}, where do you put your '{}'?"

--- a/en/python/tictactoe/step006b_medium_ai.py
+++ b/en/python/tictactoe/step006b_medium_ai.py
@@ -82,7 +82,7 @@ def choose_free_cell(free_cells, mychar) -> str:
 
 
 def make_human_coordinates(row: int, column: int) -> str:
-    """returns a human-readable string, cloumns ABC, rows 123"""
+    """returns a human-readable string, columns ABC, rows 123"""
     return "ABC"[column]+","+str(row+1)
 
 def find_winning_move(mychar: str) -> Optional[str]:

--- a/en/python/tictactoe/step006btest.py
+++ b/en/python/tictactoe/step006btest.py
@@ -14,7 +14,7 @@ def display() -> None:
 
 
 def make_human_coordinates(row: int, column: int) -> str:
-    """returns a human-readable string, cloumns ABC, rows 123"""
+    """returns a human-readable string, columns ABC, rows 123"""
     return "ABC"[column]+","+str(row+1)
 
 

--- a/en/python/tictactoe/step006c_parameters.py
+++ b/en/python/tictactoe/step006c_parameters.py
@@ -91,7 +91,7 @@ def choose_a_free_cell(cells: List[List[str]], my_char: str ,
 
 
 def make_human_coordinates(row: int, column: int) -> str:
-    """returns a human-readable string, cloumns ABC, rows 123"""
+    """returns a human-readable string, columns ABC, rows 123"""
     return "ABC"[column] + "," + str(row + 1)
 
 

--- a/examples/image_merge_and_meme.py
+++ b/examples/image_merge_and_meme.py
@@ -138,7 +138,7 @@ def get_concat_h_blank(im1, im2, color=(0, 0, 0)):
     return dst
 
 def get_concat_v_blank(im1, im2, color=(0, 0, 0)):
-    """merge images vertically, leaving blank the leftoer, see https://note.nkmk.me/en/python-pillow-basic/"""
+    """merge images vertically, leaving blank the leftover, see https://note.nkmk.me/en/python-pillow-basic/"""
     dst = PIL.Image.new('RGB', (max(im1.width, im2.width), im1.height + im2.height), color)
     dst.paste(im1, (0, 0))
     dst.paste(im2, (0, im1.height))

--- a/examples/pygameMenu.py
+++ b/examples/pygameMenu.py
@@ -84,7 +84,7 @@ class Viewer:
         # ---- video (submenu of settings) ----
         # ----list of possible video resolutions without double entries -> set ----
         reslist = list(set(pygame.display.list_modes(flags=pygame.FULLSCREEN)))
-        reslist.sort()  # sort the list from smalles resolution to biggest
+        reslist.sort()  # sort the list from smallest resolution to biggest
         # concert list of tuples( int,int) into list of strings
         # print("reslist", reslist)
         reslist = ["x".join((str(x), str(y))) for (x, y) in reslist]
@@ -283,12 +283,12 @@ class PygameMenu:
 
     @property
     def font(self):
-        """read only attribute, influened by fontname and fontsize"""
+        """read only attribute, influenced by fontname and fontsize"""
         return pygame.font.SysFont(name=self.fontname, size=self.fontsize, bold=True, italic= False)
 
     @property
     def smallfont(self):
-        """read only attribute, influened by fontname and helptextfontsize"""
+        """read only attribute, influenced by fontname and helptextfontsize"""
         return pygame.font.SysFont(name=self.fontname, size=self.helptextfontsize, bold=True, italic=False)
 
     def cursor_up(self, menupoints):
@@ -425,7 +425,7 @@ class PygameMenu:
             menupoints = [p for p in self.menu.items]
             selection = self.menu.items[self.i] # self.menudict[self.menuname][self.i]
             # ------- cursor animation --------
-            # bounce coursor from left to right:
+            # bounce cursor from left to right:
             maxcursordistance = 20
             ## first value is animation time (lower is slower), second value is travel distance of Curosr
             #cursordistance = (self.menutime * 20) % 50


### PR DESCRIPTION
There are small typos in:
- en/pygame/014_sprites.py
- en/pygame/015_more_sprites.py
- en/pygame/part2step014-sprites.py
- en/python/battleship/chat_server.py
- en/python/tictactoe/step003c_play_until_bored.py
- en/python/tictactoe/step004a_check_win.py
- en/python/tictactoe/step006b_medium_ai.py
- en/python/tictactoe/step006btest.py
- en/python/tictactoe/step006c_parameters.py
- examples/image_merge_and_meme.py
- examples/pygameMenu.py

Fixes:
- Should read `detection` rather than `detecttion`.
- Should read `columns` rather than `cloumns`.
- Should read `influenced` rather than `influened`.
- Should read `define` rather than `defnine`.
- Should read `smallest` rather than `smalles`.
- Should read `leftover` rather than `leftoer`.
- Should read `cursor` rather than `coursor`.
- Should read `address` rather than `adress`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md